### PR TITLE
Upgrade to Go 1.22

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
     - GO_SWAGGER_VERSION=v0.30.5
     - JD_VERSION=v1.7.1
     - DOCKER_BUILDX_VERSION=v0.11.2
-    - GO_CONTAINER_VERSION=1.21.3-alpine
+    - GO_CONTAINER_VERSION=1.22.2-alpine
   when:
     event:
       include:

--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
     - latest 
     - "0.4.0"
     build_args:
-    - GORELEASER_VERSION=v1.20.0
+    - GORELEASER_VERSION=v1.25.1
     - GO_SWAGGER_VERSION=v0.30.5
     - JD_VERSION=v1.7.1
     - DOCKER_BUILDX_VERSION=v0.11.2

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 160f019bfc2be302c90e2601ae7b6e8367f8f44213f7400b33abb8af0c536170
+hmac: ccbca8ff551d979538a82ff3ab396b80eb4b53eb332c5ad3390bec16b4160431
 
 ...


### PR DESCRIPTION
* Go to 1.22, which has been out for a few months
* Bump GoReleaser too while we're at it

I'm leaving Swagger and buildx alone since they tend to be more breakage prone.